### PR TITLE
Fix error in maskSoftMax

### DIFF
--- a/misc/maskSoftmax.lua
+++ b/misc/maskSoftmax.lua
@@ -32,7 +32,7 @@ function maskSoftMax:updateGradInput(input, gradOutput)
    
    data.THNN.SoftMax_updateGradInput(
       data:cdata(),
-      gradOutput[1]:cdata(),
+      gradOutput:cdata(),
       self.gradInput:cdata(),
       self.output:cdata()
    )


### PR DESCRIPTION
When I run train.lua with the features extracted from Resnet, with an attention type to Alternating and with a batch size superior to 1, I have the following error:

```
/home/cadene/torch/install/bin/luajit: /home/cadene/.luarocks/share/lua/5.1/nn/THNN.lua:110: input and gradOutput have different number of elements: input[20 x 26] has 520 elements, while gradOutput[26] has 26 elements at /tmp/luarocks_cunn-scm-1-4878/cunn/lib/THCUNN/generic/SoftMax.cu:84
stack traceback:
        [C]: in function 'v'
        /home/cadene/.luarocks/share/lua/5.1/nn/THNN.lua:110: in function 'SoftMax_updateGradInput'
        ./misc/maskSoftmax.lua:40: in function 'updateGradInput'
        /home/cadene/.luarocks/share/lua/5.1/nngraph/gmodule.lua:420: in function 'neteval'
        /home/cadene/.luarocks/share/lua/5.1/nngraph/gmodule.lua:454: in function </home/cadene/.luarocks/share/lua/5.1/nngraph/gmodule.lua:390>
        [C]: in function 'xpcall'
        ...dene/.luarocks/share/lua/5.1/nngraph/graphinspecting.lua:35: in function 'updateGradInput'
        /home/cadene/.luarocks/share/lua/5.1/nn/Module.lua:31: in function 'backward'
        ./misc/ques_level.lua:147: in function 'updateGradInput'
        /home/cadene/.luarocks/share/lua/5.1/nn/Module.lua:31: in function 'backward'
        train.lua:299: in function 'lossFun'
        train.lua:339: in main chunk
        [C]: in function 'dofile'
        ...dene/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
        [C]: at 0x00405b60
stack traceback:
        [C]: in function 'error'
        ...dene/.luarocks/share/lua/5.1/nngraph/graphinspecting.lua:43: in function 'updateGradInput'
        /home/cadene/.luarocks/share/lua/5.1/nn/Module.lua:31: in function 'backward'
        ./misc/ques_level.lua:147: in function 'updateGradInput'
        /home/cadene/.luarocks/share/lua/5.1/nn/Module.lua:31: in function 'backward'
        train.lua:299: in function 'lossFun'
        train.lua:339: in main chunk
        [C]: in function 'dofile'
        ...dene/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
        [C]: at 0x00405b60
```

In [nn.maskSoftMax](https://github.com/jiasenlu/HieCoAttenVQA/blob/master/misc/maskSoftmax.lua), `gradOutput and `self.output` are supposed to be of the same size ({batchSize, 26}).

Why do you select the first batch of `gradOutput` with `gradOutput[1]` ? It is obviously not a table.
